### PR TITLE
Allow `writable_member_repo` for npm group repos

### DIFF
--- a/files/groovy/create_repos_from_list.groovy
+++ b/files/groovy/create_repos_from_list.groovy
@@ -203,8 +203,8 @@ parsed_args.each { currentRepo ->
             ]
         }
 
-        // Configs for all docker group repos
-        if (currentRepo.type == 'group' && currentRepo.format == 'docker') {
+        // Configs for all docker/npm group repos
+        if (currentRepo.type == 'group' && currentRepo.format in ['docker', 'npm']) {
             configuration.attributes['group'] = [
                 // when setting the groupWriteMember, the memberNames must be set as well, API expects both objects
                     groupWriteMember: currentRepo.writable_member_repo,


### PR DESCRIPTION
NPM group repositories have support for writable member.

See edition comparison:
  https://www.sonatype.com/products/sonatype-nexus-oss-download

> Deploy to npm & Docker Groups